### PR TITLE
RBD Testcase to create images

### DIFF
--- a/UI/cli_options.py
+++ b/UI/cli_options.py
@@ -1,0 +1,13 @@
+def pytest_addoption(parser):
+    parser.addoption(
+        "--image-name",
+        action="store",
+        required=True,
+        help="Name of the RBD image to create"
+    )
+    parser.addoption(
+        "--image-size",
+        action="store",
+        required=True,
+        help="Size of the RBD image to create"
+    )

--- a/UI/config/data.py
+++ b/UI/config/data.py
@@ -7,7 +7,7 @@ class DashboardConfig:
     password: str
 
 TEST_CONFIG = DashboardConfig(
-    url="https://10.0.66.223:8443/",
+    url="https://10.0.65.77:8443/",
     username="admin",
     password="admin@123"
 )

--- a/UI/conftest.py
+++ b/UI/conftest.py
@@ -8,8 +8,8 @@ from selenium.webdriver.firefox.options import Options as FirefoxOptions
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import NoSuchElementException
-from config.data import TEST_CONFIG
-from facade.login import LoginFacade
+from UI.config.data import TEST_CONFIG
+from UI.facade.login import LoginFacade
 
 @pytest.fixture(scope="function")
 def driver(request):

--- a/UI/locators/rbd.py
+++ b/UI/locators/rbd.py
@@ -1,0 +1,17 @@
+from selenium.webdriver.common.by import By
+
+
+class RBDLocators:
+    BLOCK_DROPDOWN = (By.XPATH, "//span[normalize-space(.)='Block']")
+    IMAGES         = (By.XPATH, "//span[normalize-space(.)='Images']")
+
+    # Click the button, not its inner <span>
+    CREATE_IMAGE_BUTTON = (
+        By.XPATH,
+        "//button[@data-testid='primary-action' and contains(@aria-label,'Create')]",
+    )
+
+    IMAGE_NAME_INPUT = (By.XPATH, "//input[@id='name'  and @placeholder='Name...']")
+    IMAGE_SIZE_INPUT = (By.XPATH, "//input[@id='size'  and @placeholder='e.g., 10GiB']")
+    CREATE_BUTTON    = (By.XPATH, "//button[@type='submit' and contains(@aria-label,'Create Image')]")
+

--- a/UI/tests/rbd/test_rbd.py
+++ b/UI/tests/rbd/test_rbd.py
@@ -1,0 +1,55 @@
+import time
+import pytest
+from selenium.common.exceptions import TimeoutException, ElementClickInterceptedException
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.common.by import By
+
+from UI.config.data import TEST_CONFIG
+from UI.facade.login import LoginFacade
+from UI.locators.rbd import RBDLocators
+
+
+def _w(driver, t=10):
+    return WebDriverWait(driver, t)
+
+
+@pytest.mark.usefixtures("driver", "screenshot")
+def test_rbd_create_image(driver, request, screenshot):
+    name = request.config.getoption("--image-name")
+    size = request.config.getoption("--image-size")
+
+    try:
+        # ── Dashboard & (optional) login ────────────────────────────────────
+        driver.get(TEST_CONFIG.url)
+        try:
+            _w(driver, 5).until(EC.presence_of_element_located((By.ID, "username")))
+            LoginFacade(driver).login(TEST_CONFIG.username, TEST_CONFIG.password)
+        except TimeoutException:
+            pass  # already logged in
+
+        # ── Navigate Block ▸ Images ─────────────────────────────────────────
+        driver.execute_script(
+            "arguments[0].scrollIntoView(true);",
+            _w(driver).until(EC.presence_of_element_located(RBDLocators.BLOCK_DROPDOWN)),
+        )
+        _w(driver).until(EC.element_to_be_clickable(RBDLocators.BLOCK_DROPDOWN)).click()
+        _w(driver).until(EC.element_to_be_clickable(RBDLocators.IMAGES)).click()
+
+        # ── Click “Create” (with JS-fallback) ───────────────────────────────
+        create_btn = _w(driver).until(
+            EC.element_to_be_clickable(RBDLocators.CREATE_IMAGE_BUTTON)
+        )
+        try:
+            create_btn.click()
+        except ElementClickInterceptedException:
+            driver.execute_script("arguments[0].click();", create_btn)
+
+        # ── Fill form & submit ──────────────────────────────────────────────
+        _w(driver).until(EC.presence_of_element_located(RBDLocators.IMAGE_NAME_INPUT)).send_keys(name)
+        _w(driver).until(EC.presence_of_element_located(RBDLocators.IMAGE_SIZE_INPUT)).send_keys(size)
+        _w(driver).until(EC.element_to_be_clickable(RBDLocators.CREATE_BUTTON)).click()
+
+    except Exception as e:
+        screenshot(driver, "rbd_failure")
+        pytest.fail(f"❌ RBD test failed: {e}")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
+addopts = -p UI.cli_options
 markers =
     rgw: mark a test as an RGW test
+


### PR DESCRIPTION
What this PR does:
-Navigates to Block ▸ Images in the Ceph dashboard.
-Opens the Create Image modal, fills in name and size taken from CLI options (--image-name, --image-size).
-Submits the form and waits until the newly-created image row appears in the table.
-Captures a screenshot and fails if any step raises an exception.

To run the script - PYTHONPATH=. pytest tests/rbd/test_rbd.py --image-name=name --image-size=size
